### PR TITLE
FIX: Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@
 
 nervaluate is a python module for evaluating Named Entity Recognition (NER) models as defined in the SemEval 2013 - 9.1 task.
 
-The evaluation metrics output by nervaluate go beyond a simple token/tag based schema, and consider diferent scenarios based on wether all the tokens that belong to a named entity were classified or not, and also whether the correct entity type was assigned.
+The evaluation metrics output by nervaluate go beyond a simple token/tag based schema, and consider different scenarios 
+based on weather all the tokens that belong to a named entity were classified or not, and also whether the correct 
+entity type was assigned.
 
-This full problem is described in detail in the [original blog](http://www.davidsbatista.net/blog/2018/05/09/Named_Entity_Evaluation/) post by [David Batista](https://github.com/davidsbatista), and extends the code in the [original repository](https://github.com/davidsbatista/NER-Evaluation) which accompanied the blog post.
+This full problem is described in detail in the [original blog](http://www.davidsbatista.net/blog/2018/05/09/Named_Entity_Evaluation/) 
+post by [David Batista](https://github.com/davidsbatista), and extends the code in the 
+[original repository](https://github.com/davidsbatista/NER-Evaluation) which accompanied the blog post.
 
 The code draws heavily on:
 
@@ -19,7 +23,9 @@ The code draws heavily on:
 
 ### Token level evaluation for NER is too simplistic
 
-When running machine learning models for NER, it is common to report metrics at the individual token level. This may not be the best approach, as a named entity can be made up of multiple tokens, so a full-entity accuracy would be desireable.
+When running machine learning models for NER, it is common to report metrics at the individual token level. This may 
+not be the best approach, as a named entity can be made up of multiple tokens, so a full-entity accuracy would be 
+desirable.
 
 When comparing the golden standard annotations with the output of a NER system different scenarios might occur:
 
@@ -50,9 +56,13 @@ __III. System misses an entity__
 |Alto|I-LOC|O|
 |,|O|O|
 
-Based on these three scenarios we have a simple classification evaluation that can be measured in terms of false positives, true positives, false negatives and false positives, and subsequently compute precision, recall and f1-score for each named-entity type.
+Based on these three scenarios we have a simple classification evaluation that can be measured in terms of false 
+positives, true positives, false negatives and false positives, and subsequently compute precision, recall and 
+F1-score for each named-entity type.
 
-However this simple schema ignores the possibility of partial matches or other scenarios when the NER system gets the named-entity surface string correct but the type wrong, and we might also want to evaluate these scenarios again at a full-entity level.
+However this simple schema ignores the possibility of partial matches or other scenarios when the NER system gets 
+the named-entity surface string correct but the type wrong, and we might also want to evaluate these scenarios 
+again at a full-entity level.
 
 For example:
 
@@ -85,7 +95,8 @@ __VI. System gets the boundaries and entity type wrong__
 |Smith|I-PER|I-ORG|
 |resigns|O|O|
 
-How can we incorporate these described scenarios into evaluation metrics? See the [original blog](http://www.davidsbatista.net/blog/2018/05/09/Named_Entity_Evaluation/) for a great explanation, a summary is included here:
+How can we incorporate these described scenarios into evaluation metrics? See the [original blog](http://www.davidsbatista.net/blog/2018/05/09/Named_Entity_Evaluation/) 
+for a great explanation, a summary is included here:
 
 We can use the following five metrics to consider difference categories of errors:
 
@@ -117,14 +128,18 @@ These five errors and four evaluation schema interact in the following ways:
 |I|DRUG|phenytoin|DRUG|phenytoin|COR|COR|COR|COR|
 |VI|GROUP|contraceptives|DRUG|oral contraceptives|INC|PAR|INC|INC|
 
-Then precision/recall/f1-score are calculated for each different evaluation schema. In order to achieve data, two more quantities need to be calculated:
+Then precision/recall/f1-score are calculated for each different evaluation schema. In order to achieve data, two more 
+quantities need to be calculated:
 
 ```
 POSSIBLE (POS) = COR + INC + PAR + MIS = TP + FN
 ACTUAL (ACT) = COR + INC + PAR + SPU = TP + FP
 ```
 
-Then we can compute precision/recall/f1-score, where roughly describing precision is the percentage of correct named-entities found by the NER system, and recall is the percentage of the named-entities in the golden annotations that are retrieved by the NER system. This is computed in two different ways depending wether we want an exact match (i.e., strict and exact ) or a partial match (i.e., partial and type) scenario:
+Then we can compute precision/recall/f1-score, where roughly describing precision is the percentage of correct 
+named-entities found by the NER system, and recall is the percentage of the named-entities in the golden annotations 
+that are retrieved by the NER system. This is computed in two different ways depending on whether we want an exact 
+match (i.e., strict and exact ) or a partial match (i.e., partial and type) scenario:
 
 __Exact Match (i.e., strict and exact )__
 ```
@@ -153,7 +168,9 @@ __Putting all together:__
 
 ## Notes:
 
-In scenarios IV and VI the entity type of the `true` and `pred` does not match, in both cases we only scored against the true entity, not the predicted one. You can argue that the predicted entity could also be scored as spurious, but according to the definition of `spurius`:
+In scenarios IV and VI the entity type of the `true` and `pred` does not match, in both cases we only scored against 
+the true entity, not the predicted one. You can argue that the predicted entity could also be scored as spurious, 
+but according to the definition of `spurius`:
 
 * Spurius (SPU) : system produces a response which doesn’t exist in the golden annotation;
 
@@ -408,8 +425,11 @@ results, results_by_tag = evaluator.evaluate()
 
 ## Extending the package to accept more formats
 
-Additional formats can easily be added to the module by creating a converstion function in `nervaluate/utils.py`, for example `conll_to_spans()`. This function must return the spans in the prodigy style dicts shown in the prodigy example above.
+Additional formats can easily be added to the module by creating a conversion function in `nervaluate/utils.py`, 
+for example `conll_to_spans()`. This function must return the spans in the prodigy style dicts shown in the prodigy 
+example above.
 
-The new function can then be added to the list of loaders in `nervaluate/nervaluate.py`, and can then be selection with the `loader` argument when instantiating the `Evaluator` class.
+The new function can then be added to the list of loaders in `nervaluate/nervaluate.py`, and can then be selection 
+with the `loader` argument when instantiating the `Evaluator` class.
 
 A list of formats we intend to include is included in https://github.com/ivyleavedtoadflax/nervaluate/issues/3.

--- a/nervaluate/nervaluate.py
+++ b/nervaluate/nervaluate.py
@@ -4,7 +4,7 @@
 import logging
 from copy import deepcopy
 
-from nervaluate.utils import conll_to_spans, find_overlap, list_to_spans
+from .utils import conll_to_spans, find_overlap, list_to_spans
 
 logging.basicConfig(
     format="%(asctime)s %(name)s %(levelname)s: %(message)s",

--- a/nervaluate/nervaluate.py
+++ b/nervaluate/nervaluate.py
@@ -4,7 +4,7 @@
 import logging
 from copy import deepcopy
 
-from .utils import conll_to_spans, find_overlap, list_to_spans
+from nervaluate.utils import conll_to_spans, find_overlap, list_to_spans
 
 logging.basicConfig(
     format="%(asctime)s %(name)s %(levelname)s: %(message)s",


### PR DESCRIPTION
- Fix some typos and errors
- Truncated the documentation at 120 characters to be easy to read/maintain in a text editor - this has no changes in how it appears on rendered README.MD
