### PR TITLE
Add more information to outputs (add instance indices for error types)

### DIFF
--- a/src/nervaluate/__init__.py
+++ b/src/nervaluate/__init__.py
@@ -7,5 +7,7 @@ from .evaluate import (
     find_overlap,
     summary_report_ent,
     summary_report_overall,
+    summary_report_ents_indices,
+    summary_report_overall_indices,
 )
 from .utils import collect_named_entities, conll_to_spans, list_to_spans, split_list

--- a/src/nervaluate/evaluate.py
+++ b/src/nervaluate/evaluate.py
@@ -51,7 +51,7 @@ class Evaluator:  # pylint: disable=too-many-instance-attributes, too-few-public
 
         self.loader = loader
 
-        self.eval_indices = {
+        self.eval_indices: Dict[str, List[int]] = {
             "correct_indices": [],
             "incorrect_indices": [],
             "partial_indices": [],
@@ -68,7 +68,7 @@ class Evaluator:  # pylint: disable=too-many-instance-attributes, too-few-public
         }
         self.evaluation_agg_indices = {e: deepcopy(self.evaluation_indices) for e in tags}
 
-    def evaluate(self) -> Tuple[Dict, Dict]:
+    def evaluate(self) -> Tuple[Dict, Dict, Dict, Dict]:
         logging.debug("Imported %s predictions for %s true examples", len(self.pred), len(self.true))
 
         if self.loader != "default":
@@ -81,7 +81,9 @@ class Evaluator:  # pylint: disable=too-many-instance-attributes, too-few-public
 
         for index, (true_ents, pred_ents) in enumerate(zip(self.true, self.pred)):
             # Compute results for one message
-            tmp_results, tmp_agg_results, tmp_results_indices, tmp_agg_results_indices = compute_metrics(true_ents, pred_ents, self.tags, index)
+            tmp_results, tmp_agg_results, tmp_results_indices, tmp_agg_results_indices = compute_metrics(
+                true_ents, pred_ents, self.tags, index
+            )
 
             # Cycle through each result and accumulate
             # TODO: Combine these loops below:
@@ -106,7 +108,9 @@ class Evaluator:  # pylint: disable=too-many-instance-attributes, too-few-public
 
                     # Accumulate indices for each error type per entity type
                     for error_type in self.evaluation_agg_indices[label][eval_schema]:
-                        self.evaluation_agg_indices[label][eval_schema][error_type] += tmp_agg_results_indices[label][eval_schema][error_type]
+                        self.evaluation_agg_indices[label][eval_schema][error_type] += tmp_agg_results_indices[label][
+                            eval_schema
+                        ][error_type]
 
                 # Calculate precision recall at the individual entity level
                 self.evaluation_agg_entities_type[label] = compute_precision_recall_wrapper(
@@ -158,7 +162,7 @@ def compute_metrics(  # type: ignore
     # results by entity type
     evaluation_agg_entities_type = {e: deepcopy(evaluation) for e in tags}
 
-    eval_ent_indices = {
+    eval_ent_indices: Dict[str, List[int]] = {
         "correct_indices": [],
         "incorrect_indices": [],
         "partial_indices": [],
@@ -214,7 +218,6 @@ def compute_metrics(  # type: ignore
             evaluation_ent_indices["ent_type"]["correct_indices"].append(instance_index)
             evaluation_ent_indices["exact"]["correct_indices"].append(instance_index)
             evaluation_ent_indices["partial"]["correct_indices"].append(instance_index)
-
 
             # for the agg. by label results
             evaluation_agg_entities_type[pred["label"]]["strict"]["correct"] += 1
@@ -310,7 +313,9 @@ def compute_metrics(  # type: ignore
                         evaluation_agg_entities_type[true["label"]]["partial"]["partial"] += 1
                         evaluation_agg_ent_indices[true["label"]]["partial"]["partial_indices"].append(instance_index)
                         evaluation_agg_entities_type[true["label"]]["ent_type"]["incorrect"] += 1
-                        evaluation_agg_ent_indices[true["label"]]["ent_type"]["incorrect_indices"].append(instance_index)
+                        evaluation_agg_ent_indices[true["label"]]["ent_type"]["incorrect_indices"].append(
+                            instance_index
+                        )
                         evaluation_agg_entities_type[true["label"]]["exact"]["incorrect"] += 1
                         evaluation_agg_ent_indices[true["label"]]["exact"]["incorrect_indices"].append(instance_index)
 

--- a/src/nervaluate/evaluate.py
+++ b/src/nervaluate/evaluate.py
@@ -412,7 +412,7 @@ def compute_metrics(  # type: ignore
                     )
 
     # Scenario III: Entity was missed entirely.
-    for true in true_named_entities:
+    for within_instance_index, true in enumerate(true_named_entities):
         if true in true_which_overlapped_with_pred:
             continue
 
@@ -620,7 +620,7 @@ def summary_report_overall(results: Dict, digits: int = 2) -> str:
     return report
 
 
-def summary_report_ents_indices(evaluation_agg_indices: Dict, error_schema: str, preds: Optional[List] = None) -> str:
+def summary_report_ents_indices(evaluation_agg_indices: Dict, error_schema: str, preds: Optional[List] = [[]]) -> str:
     """
     Usage: print(summary_report_ents_indices(evaluation_agg_indices, 'partial', preds))
     """
@@ -634,8 +634,8 @@ def summary_report_ents_indices(evaluation_agg_indices: Dict, error_schema: str,
             report += f"    ({entity_type}) {category_name}:\n"
             if indices:
                 for instance_index, entity_index in indices:
-                    if preds is not None:
-                        pred = preds[instance_index][entity_index]
+                    if preds is not [[]]:
+                        pred = preds[instance_index][entity_index]  # type: ignore
                         prediction_info = f"Label={pred['label']}, Start={pred['start']}, End={pred['end']}"
                         report += f"      - Instance {instance_index}, Entity {entity_index}: {prediction_info}\n"
                     else:
@@ -645,7 +645,7 @@ def summary_report_ents_indices(evaluation_agg_indices: Dict, error_schema: str,
     return report
 
 
-def summary_report_overall_indices(evaluation_indices: Dict, error_schema: str, preds: Optional[List] = None) -> str:
+def summary_report_overall_indices(evaluation_indices: Dict, error_schema: str, preds: Optional[List] = [[]]) -> str:
     """
     Usage: print(summary_report_overall_indices(evaluation_indices, 'partial', preds))
     """
@@ -660,9 +660,9 @@ def summary_report_overall_indices(evaluation_indices: Dict, error_schema: str, 
         report += f"{category_name} indices:\n"
         if indices:
             for instance_index, entity_index in indices:
-                if preds is not None:
+                if preds is not [[]]:
                     # Retrieve the corresponding prediction
-                    pred = preds[instance_index][entity_index]
+                    pred = preds[instance_index][entity_index]  # type: ignore
                     prediction_info = f"Label={pred['label']}, Start={pred['start']}, End={pred['end']}"
                     report += f"  - Instance {instance_index}, Entity {entity_index}: {prediction_info}\n"
                 else:

--- a/src/nervaluate/evaluate.py
+++ b/src/nervaluate/evaluate.py
@@ -209,12 +209,21 @@ def compute_metrics(  # type: ignore
             evaluation["ent_type"]["correct"] += 1
             evaluation["exact"]["correct"] += 1
             evaluation["partial"]["correct"] += 1
+            evaluation_indices["strict"]["correct_indices"].append(index)
+            evaluation_indices["ent_type"]["correct_indices"].append(index)
+            evaluation_indices["exact"]["correct_indices"].append(index)
+            evaluation_indices["partial"]["correct_indices"].append(index)
+
 
             # for the agg. by label results
             evaluation_agg_entities_type[pred["label"]]["strict"]["correct"] += 1
             evaluation_agg_entities_type[pred["label"]]["ent_type"]["correct"] += 1
             evaluation_agg_entities_type[pred["label"]]["exact"]["correct"] += 1
             evaluation_agg_entities_type[pred["label"]]["partial"]["correct"] += 1
+            evaluation_agg_indices[pred["label"]]["strict"]["correct_indices"].append(index)
+            evaluation_agg_indices[pred["label"]]["ent_type"]["correct_indices"].append(index)
+            evaluation_agg_indices[pred["label"]]["exact"]["correct_indices"].append(index)
+            evaluation_agg_indices[pred["label"]]["partial"]["correct_indices"].append(index)
 
         else:
             # check for overlaps with any of the true entities

--- a/src/nervaluate/evaluate.py
+++ b/src/nervaluate/evaluate.py
@@ -162,7 +162,7 @@ def compute_metrics(  # type: ignore
     # results by entity type
     evaluation_agg_entities_type = {e: deepcopy(evaluation) for e in tags}
 
-    eval_ent_indices: Dict[str, List[int]] = {
+    eval_ent_indices: Dict[str, List[Tuple[int, int]]] = {
         "correct_indices": [],
         "incorrect_indices": [],
         "partial_indices": [],
@@ -200,7 +200,7 @@ def compute_metrics(  # type: ignore
     pred_named_entities.sort(key=lambda x: x["end"])
 
     # go through each predicted named-entity
-    for pred in pred_named_entities:
+    for within_instance_index, pred in enumerate(pred_named_entities):
         found_overlap = False
 
         # Check each of the potential scenarios in turn. See
@@ -214,20 +214,28 @@ def compute_metrics(  # type: ignore
             evaluation["ent_type"]["correct"] += 1
             evaluation["exact"]["correct"] += 1
             evaluation["partial"]["correct"] += 1
-            evaluation_ent_indices["strict"]["correct_indices"].append(instance_index)
-            evaluation_ent_indices["ent_type"]["correct_indices"].append(instance_index)
-            evaluation_ent_indices["exact"]["correct_indices"].append(instance_index)
-            evaluation_ent_indices["partial"]["correct_indices"].append(instance_index)
+            evaluation_ent_indices["strict"]["correct_indices"].append((instance_index, within_instance_index))
+            evaluation_ent_indices["ent_type"]["correct_indices"].append((instance_index, within_instance_index))
+            evaluation_ent_indices["exact"]["correct_indices"].append((instance_index, within_instance_index))
+            evaluation_ent_indices["partial"]["correct_indices"].append((instance_index, within_instance_index))
 
             # for the agg. by label results
             evaluation_agg_entities_type[pred["label"]]["strict"]["correct"] += 1
             evaluation_agg_entities_type[pred["label"]]["ent_type"]["correct"] += 1
             evaluation_agg_entities_type[pred["label"]]["exact"]["correct"] += 1
             evaluation_agg_entities_type[pred["label"]]["partial"]["correct"] += 1
-            evaluation_agg_ent_indices[pred["label"]]["strict"]["correct_indices"].append(instance_index)
-            evaluation_agg_ent_indices[pred["label"]]["ent_type"]["correct_indices"].append(instance_index)
-            evaluation_agg_ent_indices[pred["label"]]["exact"]["correct_indices"].append(instance_index)
-            evaluation_agg_ent_indices[pred["label"]]["partial"]["correct_indices"].append(instance_index)
+            evaluation_agg_ent_indices[pred["label"]]["strict"]["correct_indices"].append(
+                (instance_index, within_instance_index)
+            )
+            evaluation_agg_ent_indices[pred["label"]]["ent_type"]["correct_indices"].append(
+                (instance_index, within_instance_index)
+            )
+            evaluation_agg_ent_indices[pred["label"]]["exact"]["correct_indices"].append(
+                (instance_index, within_instance_index)
+            )
+            evaluation_agg_ent_indices[pred["label"]]["partial"]["correct_indices"].append(
+                (instance_index, within_instance_index)
+            )
 
         else:
             # check for overlaps with any of the true entities
@@ -244,17 +252,25 @@ def compute_metrics(  # type: ignore
                 if true["start"] == pred["start"] and pred["end"] == true["end"] and true["label"] != pred["label"]:
                     # overall results
                     evaluation["strict"]["incorrect"] += 1
-                    evaluation_ent_indices["strict"]["incorrect_indices"].append(instance_index)
+                    evaluation_ent_indices["strict"]["incorrect_indices"].append(
+                        (instance_index, within_instance_index)
+                    )
                     evaluation["ent_type"]["incorrect"] += 1
-                    evaluation_ent_indices["ent_type"]["incorrect_indices"].append(instance_index)
+                    evaluation_ent_indices["ent_type"]["incorrect_indices"].append(
+                        (instance_index, within_instance_index)
+                    )
                     evaluation["partial"]["correct"] += 1
                     evaluation["exact"]["correct"] += 1
 
                     # aggregated by entity type results
                     evaluation_agg_entities_type[true["label"]]["strict"]["incorrect"] += 1
-                    evaluation_agg_ent_indices[true["label"]]["strict"]["incorrect_indices"].append(instance_index)
+                    evaluation_agg_ent_indices[true["label"]]["strict"]["incorrect_indices"].append(
+                        (instance_index, within_instance_index)
+                    )
                     evaluation_agg_entities_type[true["label"]]["ent_type"]["incorrect"] += 1
-                    evaluation_agg_ent_indices[true["label"]]["ent_type"]["incorrect_indices"].append(instance_index)
+                    evaluation_agg_ent_indices[true["label"]]["ent_type"]["incorrect_indices"].append(
+                        (instance_index, within_instance_index)
+                    )
                     evaluation_agg_entities_type[true["label"]]["partial"]["correct"] += 1
                     evaluation_agg_entities_type[true["label"]]["exact"]["correct"] += 1
 
@@ -273,21 +289,33 @@ def compute_metrics(  # type: ignore
                     if pred["label"] == true["label"]:
                         # overall results
                         evaluation["strict"]["incorrect"] += 1
-                        evaluation_ent_indices["strict"]["incorrect_indices"].append(instance_index)
+                        evaluation_ent_indices["strict"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation["ent_type"]["correct"] += 1
                         evaluation["partial"]["partial"] += 1
-                        evaluation_ent_indices["partial"]["partial_indices"].append(instance_index)
+                        evaluation_ent_indices["partial"]["partial_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation["exact"]["incorrect"] += 1
-                        evaluation_ent_indices["exact"]["incorrect_indices"].append(instance_index)
+                        evaluation_ent_indices["exact"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
 
                         # aggregated by entity type results
                         evaluation_agg_entities_type[true["label"]]["strict"]["incorrect"] += 1
-                        evaluation_agg_ent_indices[true["label"]]["strict"]["incorrect_indices"].append(instance_index)
+                        evaluation_agg_ent_indices[true["label"]]["strict"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation_agg_entities_type[true["label"]]["ent_type"]["correct"] += 1
                         evaluation_agg_entities_type[true["label"]]["partial"]["partial"] += 1
-                        evaluation_agg_ent_indices[true["label"]]["partial"]["partial_indices"].append(instance_index)
+                        evaluation_agg_ent_indices[true["label"]]["partial"]["partial_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation_agg_entities_type[true["label"]]["exact"]["incorrect"] += 1
-                        evaluation_agg_ent_indices[true["label"]]["exact"]["incorrect_indices"].append(instance_index)
+                        evaluation_agg_ent_indices[true["label"]]["exact"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
 
                         found_overlap = True
 
@@ -297,27 +325,41 @@ def compute_metrics(  # type: ignore
 
                         # overall results
                         evaluation["strict"]["incorrect"] += 1
-                        evaluation_ent_indices["strict"]["incorrect_indices"].append(instance_index)
+                        evaluation_ent_indices["strict"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation["ent_type"]["incorrect"] += 1
-                        evaluation_ent_indices["ent_type"]["incorrect_indices"].append(instance_index)
+                        evaluation_ent_indices["ent_type"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation["partial"]["partial"] += 1
-                        evaluation_ent_indices["partial"]["partial_indices"].append(instance_index)
+                        evaluation_ent_indices["partial"]["partial_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation["exact"]["incorrect"] += 1
-                        evaluation_ent_indices["exact"]["incorrect_indices"].append(instance_index)
+                        evaluation_ent_indices["exact"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
 
                         # aggregated by entity type results
                         # Results against the true entity
 
                         evaluation_agg_entities_type[true["label"]]["strict"]["incorrect"] += 1
-                        evaluation_agg_ent_indices[true["label"]]["strict"]["incorrect_indices"].append(instance_index)
+                        evaluation_agg_ent_indices[true["label"]]["strict"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation_agg_entities_type[true["label"]]["partial"]["partial"] += 1
-                        evaluation_agg_ent_indices[true["label"]]["partial"]["partial_indices"].append(instance_index)
+                        evaluation_agg_ent_indices[true["label"]]["partial"]["partial_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
                         evaluation_agg_entities_type[true["label"]]["ent_type"]["incorrect"] += 1
                         evaluation_agg_ent_indices[true["label"]]["ent_type"]["incorrect_indices"].append(
-                            instance_index
+                            (instance_index, within_instance_index)
                         )
                         evaluation_agg_entities_type[true["label"]]["exact"]["incorrect"] += 1
-                        evaluation_agg_ent_indices[true["label"]]["exact"]["incorrect_indices"].append(instance_index)
+                        evaluation_agg_ent_indices[true["label"]]["exact"]["incorrect_indices"].append(
+                            (instance_index, within_instance_index)
+                        )
 
                         # Results against the predicted entity
                         # evaluation_agg_entities_type[pred['label']]['strict']['spurious'] += 1
@@ -327,13 +369,13 @@ def compute_metrics(  # type: ignore
             if not found_overlap:
                 # Overall results
                 evaluation["strict"]["spurious"] += 1
-                evaluation_ent_indices["strict"]["spurious_indices"].append(instance_index)
+                evaluation_ent_indices["strict"]["spurious_indices"].append((instance_index, within_instance_index))
                 evaluation["ent_type"]["spurious"] += 1
-                evaluation_ent_indices["ent_type"]["spurious_indices"].append(instance_index)
+                evaluation_ent_indices["ent_type"]["spurious_indices"].append((instance_index, within_instance_index))
                 evaluation["partial"]["spurious"] += 1
-                evaluation_ent_indices["partial"]["spurious_indices"].append(instance_index)
+                evaluation_ent_indices["partial"]["spurious_indices"].append((instance_index, within_instance_index))
                 evaluation["exact"]["spurious"] += 1
-                evaluation_ent_indices["exact"]["spurious_indices"].append(instance_index)
+                evaluation_ent_indices["exact"]["spurious_indices"].append((instance_index, within_instance_index))
 
                 # Aggregated by entity type results
 
@@ -353,13 +395,21 @@ def compute_metrics(  # type: ignore
 
                 for true in spurious_tags:
                     evaluation_agg_entities_type[true]["strict"]["spurious"] += 1
-                    evaluation_agg_ent_indices[true]["strict"]["spurious_indices"].append(instance_index)
+                    evaluation_agg_ent_indices[true]["strict"]["spurious_indices"].append(
+                        (instance_index, within_instance_index)
+                    )
                     evaluation_agg_entities_type[true]["ent_type"]["spurious"] += 1
-                    evaluation_agg_ent_indices[true]["ent_type"]["spurious_indices"].append(instance_index)
+                    evaluation_agg_ent_indices[true]["ent_type"]["spurious_indices"].append(
+                        (instance_index, within_instance_index)
+                    )
                     evaluation_agg_entities_type[true]["partial"]["spurious"] += 1
-                    evaluation_agg_ent_indices[true]["partial"]["spurious_indices"].append(instance_index)
+                    evaluation_agg_ent_indices[true]["partial"]["spurious_indices"].append(
+                        (instance_index, within_instance_index)
+                    )
                     evaluation_agg_entities_type[true]["exact"]["spurious"] += 1
-                    evaluation_agg_ent_indices[true]["exact"]["spurious_indices"].append(instance_index)
+                    evaluation_agg_ent_indices[true]["exact"]["spurious_indices"].append(
+                        (instance_index, within_instance_index)
+                    )
 
     # Scenario III: Entity was missed entirely.
     for true in true_named_entities:
@@ -368,23 +418,31 @@ def compute_metrics(  # type: ignore
 
         # overall results
         evaluation["strict"]["missed"] += 1
-        evaluation_ent_indices["strict"]["missed_indices"].append(instance_index)
+        evaluation_ent_indices["strict"]["missed_indices"].append((instance_index, within_instance_index))
         evaluation["ent_type"]["missed"] += 1
-        evaluation_ent_indices["ent_type"]["missed_indices"].append(instance_index)
+        evaluation_ent_indices["ent_type"]["missed_indices"].append((instance_index, within_instance_index))
         evaluation["partial"]["missed"] += 1
-        evaluation_ent_indices["partial"]["missed_indices"].append(instance_index)
+        evaluation_ent_indices["partial"]["missed_indices"].append((instance_index, within_instance_index))
         evaluation["exact"]["missed"] += 1
-        evaluation_ent_indices["exact"]["missed_indices"].append(instance_index)
+        evaluation_ent_indices["exact"]["missed_indices"].append((instance_index, within_instance_index))
 
         # for the agg. by label
         evaluation_agg_entities_type[true["label"]]["strict"]["missed"] += 1
-        evaluation_agg_ent_indices[true["label"]]["strict"]["missed_indices"].append(instance_index)
+        evaluation_agg_ent_indices[true["label"]]["strict"]["missed_indices"].append(
+            (instance_index, within_instance_index)
+        )
         evaluation_agg_entities_type[true["label"]]["ent_type"]["missed"] += 1
-        evaluation_agg_ent_indices[true["label"]]["ent_type"]["missed_indices"].append(instance_index)
+        evaluation_agg_ent_indices[true["label"]]["ent_type"]["missed_indices"].append(
+            (instance_index, within_instance_index)
+        )
         evaluation_agg_entities_type[true["label"]]["partial"]["missed"] += 1
-        evaluation_agg_ent_indices[true["label"]]["partial"]["missed_indices"].append(instance_index)
+        evaluation_agg_ent_indices[true["label"]]["partial"]["missed_indices"].append(
+            (instance_index, within_instance_index)
+        )
         evaluation_agg_entities_type[true["label"]]["exact"]["missed"] += 1
-        evaluation_agg_ent_indices[true["label"]]["exact"]["missed_indices"].append(instance_index)
+        evaluation_agg_ent_indices[true["label"]]["exact"]["missed_indices"].append(
+            (instance_index, within_instance_index)
+        )
 
     # Compute 'possible', 'actual' according to SemEval-2013 Task 9.1 on the
     # overall results, and use these to calculate precision and recall.

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -17,7 +17,7 @@ def test_evaluator_simple_case():
         ],
     ]
     evaluator = Evaluator(true, pred, tags=["LOC", "PER"])
-    results, _ = evaluator.evaluate()
+    results, _, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 3,
@@ -92,7 +92,7 @@ def test_evaluator_simple_case_filtered_tags():
         ],
     ]
     evaluator = Evaluator(true, pred, tags=["PER", "LOC"])
-    results, _ = evaluator.evaluate()
+    results, _, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 3,
@@ -159,7 +159,7 @@ def test_evaluator_extra_classes():
         [{"label": "FOO", "start": 1, "end": 3}],
     ]
     evaluator = Evaluator(true, pred, tags=["ORG", "FOO"])
-    results, _ = evaluator.evaluate()
+    results, _, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 0,
@@ -226,7 +226,7 @@ def test_evaluator_no_entities_in_prediction():
         [],
     ]
     evaluator = Evaluator(true, pred, tags=["PER"])
-    results, _ = evaluator.evaluate()
+    results, _, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 0,
@@ -293,7 +293,7 @@ def test_evaluator_compare_results_and_results_agg():
         [{"label": "PER", "start": 2, "end": 4}],
     ]
     evaluator = Evaluator(true, pred, tags=["PER"])
-    results, results_agg = evaluator.evaluate()
+    results, results_agg, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 1,
@@ -426,7 +426,7 @@ def test_evaluator_compare_results_and_results_agg_1():
         [{"label": "MISC", "start": 2, "end": 4}],
     ]
     evaluator = Evaluator(true, pred, tags=["PER", "ORG", "MISC"])
-    results, results_agg = evaluator.evaluate()
+    results, results_agg, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 2,
@@ -612,7 +612,7 @@ def test_evaluator_with_extra_keys_in_pred():
         ],
     ]
     evaluator = Evaluator(true, pred, tags=["LOC", "PER"])
-    results, _ = evaluator.evaluate()
+    results, _, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 3,
@@ -686,7 +686,7 @@ def test_evaluator_with_extra_keys_in_true():
         ],
     ]
     evaluator = Evaluator(true, pred, tags=["LOC", "PER"])
-    results, _ = evaluator.evaluate()
+    results, _, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 3,
@@ -759,7 +759,7 @@ def test_issue_29():
         ]
     ]
     evaluator = Evaluator(true, pred, tags=["PER"])
-    results, _ = evaluator.evaluate()
+    results, _, _, _ = evaluator.evaluate()
     expected = {
         "strict": {
             "correct": 1,

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,3 +1,4 @@
+# pylint: disable=C0302
 from nervaluate import Evaluator
 
 
@@ -815,3 +816,244 @@ def test_issue_29():
     assert results["ent_type"] == expected["ent_type"]
     assert results["partial"] == expected["partial"]
     assert results["exact"] == expected["exact"]
+
+
+def test_evaluator_compare_results_indices_and_results_agg_indices():
+    """Check that the label level results match the total results."""
+    true = [
+        [{"label": "PER", "start": 2, "end": 4}],
+    ]
+    pred = [
+        [{"label": "PER", "start": 2, "end": 4}],
+    ]
+    evaluator = Evaluator(true, pred, tags=["PER"])
+    _, _, evaluation_indices, evaluation_agg_indices = evaluator.evaluate()
+    expected_evaluation_indices = {
+        "strict": {
+            "correct_indices": [(0, 0)],
+            "incorrect_indices": [],
+            "partial_indices": [],
+            "missed_indices": [],
+            "spurious_indices": [],
+        },
+        "ent_type": {
+            "correct_indices": [(0, 0)],
+            "incorrect_indices": [],
+            "partial_indices": [],
+            "missed_indices": [],
+            "spurious_indices": [],
+        },
+        "partial": {
+            "correct_indices": [(0, 0)],
+            "incorrect_indices": [],
+            "partial_indices": [],
+            "missed_indices": [],
+            "spurious_indices": [],
+        },
+        "exact": {
+            "correct_indices": [(0, 0)],
+            "incorrect_indices": [],
+            "partial_indices": [],
+            "missed_indices": [],
+            "spurious_indices": [],
+        },
+    }
+    expected_evaluation_agg_indices = {
+        "PER": {
+            "strict": {
+                "correct_indices": [(0, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "ent_type": {
+                "correct_indices": [(0, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "partial": {
+                "correct_indices": [(0, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "exact": {
+                "correct_indices": [(0, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+        }
+    }
+    assert evaluation_agg_indices["PER"]["strict"] == expected_evaluation_agg_indices["PER"]["strict"]
+    assert evaluation_agg_indices["PER"]["ent_type"] == expected_evaluation_agg_indices["PER"]["ent_type"]
+    assert evaluation_agg_indices["PER"]["partial"] == expected_evaluation_agg_indices["PER"]["partial"]
+    assert evaluation_agg_indices["PER"]["exact"] == expected_evaluation_agg_indices["PER"]["exact"]
+
+    assert evaluation_indices["strict"] == expected_evaluation_indices["strict"]
+    assert evaluation_indices["ent_type"] == expected_evaluation_indices["ent_type"]
+    assert evaluation_indices["partial"] == expected_evaluation_indices["partial"]
+    assert evaluation_indices["exact"] == expected_evaluation_indices["exact"]
+
+    assert evaluation_indices["strict"] == expected_evaluation_agg_indices["PER"]["strict"]
+    assert evaluation_indices["ent_type"] == expected_evaluation_agg_indices["PER"]["ent_type"]
+    assert evaluation_indices["partial"] == expected_evaluation_agg_indices["PER"]["partial"]
+    assert evaluation_indices["exact"] == expected_evaluation_agg_indices["PER"]["exact"]
+
+
+def test_evaluator_compare_results_indices_and_results_agg_indices_1():
+    """Test case when model predicts a label not in the test data."""
+    true = [
+        [],
+        [{"label": "ORG", "start": 2, "end": 4}],
+        [{"label": "MISC", "start": 2, "end": 4}],
+    ]
+    pred = [
+        [{"label": "PER", "start": 2, "end": 4}],
+        [{"label": "ORG", "start": 2, "end": 4}],
+        [{"label": "MISC", "start": 2, "end": 4}],
+    ]
+    evaluator = Evaluator(true, pred, tags=["PER", "ORG", "MISC"])
+    _, _, evaluation_indices, evaluation_agg_indices = evaluator.evaluate()
+
+    expected_evaluation_indices = {
+        "strict": {
+            "correct_indices": [(1, 0), (2, 0)],
+            "incorrect_indices": [],
+            "partial_indices": [],
+            "missed_indices": [],
+            "spurious_indices": [(0, 0)],
+        },
+        "ent_type": {
+            "correct_indices": [(1, 0), (2, 0)],
+            "incorrect_indices": [],
+            "partial_indices": [],
+            "missed_indices": [],
+            "spurious_indices": [(0, 0)],
+        },
+        "partial": {
+            "correct_indices": [(1, 0), (2, 0)],
+            "incorrect_indices": [],
+            "partial_indices": [],
+            "missed_indices": [],
+            "spurious_indices": [(0, 0)],
+        },
+        "exact": {
+            "correct_indices": [(1, 0), (2, 0)],
+            "incorrect_indices": [],
+            "partial_indices": [],
+            "missed_indices": [],
+            "spurious_indices": [(0, 0)],
+        },
+    }
+    expected_evaluation_agg_indices = {
+        "PER": {
+            "strict": {
+                "correct_indices": [],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [(0, 0)],
+            },
+            "ent_type": {
+                "correct_indices": [],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [(0, 0)],
+            },
+            "partial": {
+                "correct_indices": [],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [(0, 0)],
+            },
+            "exact": {
+                "correct_indices": [],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [(0, 0)],
+            },
+        },
+        "ORG": {
+            "strict": {
+                "correct_indices": [(1, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "ent_type": {
+                "correct_indices": [(1, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "partial": {
+                "correct_indices": [(1, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "exact": {
+                "correct_indices": [(1, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+        },
+        "MISC": {
+            "strict": {
+                "correct_indices": [(2, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "ent_type": {
+                "correct_indices": [(2, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "partial": {
+                "correct_indices": [(2, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+            "exact": {
+                "correct_indices": [(2, 0)],
+                "incorrect_indices": [],
+                "partial_indices": [],
+                "missed_indices": [],
+                "spurious_indices": [],
+            },
+        },
+    }
+    assert evaluation_agg_indices["ORG"]["strict"] == expected_evaluation_agg_indices["ORG"]["strict"]
+    assert evaluation_agg_indices["ORG"]["ent_type"] == expected_evaluation_agg_indices["ORG"]["ent_type"]
+    assert evaluation_agg_indices["ORG"]["partial"] == expected_evaluation_agg_indices["ORG"]["partial"]
+    assert evaluation_agg_indices["ORG"]["exact"] == expected_evaluation_agg_indices["ORG"]["exact"]
+
+    assert evaluation_agg_indices["MISC"]["strict"] == expected_evaluation_agg_indices["MISC"]["strict"]
+    assert evaluation_agg_indices["MISC"]["ent_type"] == expected_evaluation_agg_indices["MISC"]["ent_type"]
+    assert evaluation_agg_indices["MISC"]["partial"] == expected_evaluation_agg_indices["MISC"]["partial"]
+    assert evaluation_agg_indices["MISC"]["exact"] == expected_evaluation_agg_indices["MISC"]["exact"]
+
+    assert evaluation_indices["strict"] == expected_evaluation_indices["strict"]
+    assert evaluation_indices["ent_type"] == expected_evaluation_indices["ent_type"]
+    assert evaluation_indices["partial"] == expected_evaluation_indices["partial"]
+    assert evaluation_indices["exact"] == expected_evaluation_indices["exact"]

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -50,9 +50,9 @@ def test_loaders_produce_the_same_results():
 
     evaluator_prod = Evaluator(true_prod, pred_prod, tags=["PER", "ORG", "MISC"])
 
-    _, _ = evaluator_list.evaluate()
-    _, _ = evaluator_prod.evaluate()
-    _, _ = evaluator_conll.evaluate()
+    _, _, _, _ = evaluator_list.evaluate()
+    _, _, _, _ = evaluator_prod.evaluate()
+    _, _, _, _ = evaluator_conll.evaluate()
 
     assert evaluator_prod.pred == evaluator_list.pred == evaluator_conll.pred
     assert evaluator_prod.true == evaluator_list.true == evaluator_conll.true

--- a/tests/test_nervaluate.py
+++ b/tests/test_nervaluate.py
@@ -835,54 +835,54 @@ def test_compute_metrics_one_pred_two_true():
     results2, _, _, _ = compute_metrics(true_named_entities_2, pred_named_entities, ["A", "B"])
 
     expected = {
-        'ent_type': {
-            'correct': 1,
-            'incorrect': 1,
-            'partial': 0,
-            'missed': 0,
-            'spurious': 0,
-            'possible': 2,
-            'actual': 2,
-            'precision': 0,
-            'recall': 0,
-            'f1': 0
+        "ent_type": {
+            "correct": 1,
+            "incorrect": 1,
+            "partial": 0,
+            "missed": 0,
+            "spurious": 0,
+            "possible": 2,
+            "actual": 2,
+            "precision": 0,
+            "recall": 0,
+            "f1": 0,
         },
-        'partial': {
-            'correct': 0,
-            'incorrect': 0,
-            'partial': 2,
-            'missed': 0,
-            'spurious': 0,
-            'possible': 2,
-            'actual': 2,
-            'precision': 0,
-            'recall': 0,
-            'f1': 0
+        "partial": {
+            "correct": 0,
+            "incorrect": 0,
+            "partial": 2,
+            "missed": 0,
+            "spurious": 0,
+            "possible": 2,
+            "actual": 2,
+            "precision": 0,
+            "recall": 0,
+            "f1": 0,
         },
-        'strict': {
-            'correct': 0,
-            'incorrect': 2,
-            'partial': 0,
-            'missed': 0,
-            'spurious': 0,
-            'possible': 2,
-            'actual': 2,
-            'precision': 0,
-            'recall': 0,
-            'f1': 0
+        "strict": {
+            "correct": 0,
+            "incorrect": 2,
+            "partial": 0,
+            "missed": 0,
+            "spurious": 0,
+            "possible": 2,
+            "actual": 2,
+            "precision": 0,
+            "recall": 0,
+            "f1": 0,
         },
-        'exact': {
-            'correct': 0,
-            'incorrect': 2,
-            'partial': 0,
-            'missed': 0,
-            'spurious': 0,
-            'possible': 2,
-            'actual': 2,
-            'precision': 0,
-            'recall': 0,
-            'f1': 0
-        }
+        "exact": {
+            "correct": 0,
+            "incorrect": 2,
+            "partial": 0,
+            "missed": 0,
+            "spurious": 0,
+            "possible": 2,
+            "actual": 2,
+            "precision": 0,
+            "recall": 0,
+            "f1": 0,
+        },
     }
 
     assert results1 == expected

--- a/tests/test_nervaluate.py
+++ b/tests/test_nervaluate.py
@@ -23,7 +23,7 @@ def test_compute_metrics_case_1():
         {"label": "LOC", "start": 208, "end": 219},
         {"label": "LOC", "start": 225, "end": 243},
     ]
-    results, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC", "MISC"])
+    results, _, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC", "MISC"])
     results = compute_precision_recall_wrapper(results)
     expected = {
         "strict": {
@@ -81,7 +81,7 @@ def test_compute_metrics_case_1():
 def test_compute_metrics_agg_scenario_3():
     true_named_entities = [{"label": "PER", "start": 59, "end": 69}]
     pred_named_entities = []
-    _, results_agg = compute_metrics(true_named_entities, pred_named_entities, ["PER"])
+    _, results_agg, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER"])
     expected_agg = {
         "PER": {
             "strict": {
@@ -144,7 +144,7 @@ def test_compute_metrics_agg_scenario_3():
 def test_compute_metrics_agg_scenario_2():
     true_named_entities = []
     pred_named_entities = [{"label": "PER", "start": 59, "end": 69}]
-    _, results_agg = compute_metrics(true_named_entities, pred_named_entities, ["PER"])
+    _, results_agg, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER"])
     expected_agg = {
         "PER": {
             "strict": {
@@ -207,7 +207,7 @@ def test_compute_metrics_agg_scenario_2():
 def test_compute_metrics_agg_scenario_5():
     true_named_entities = [{"label": "PER", "start": 59, "end": 69}]
     pred_named_entities = [{"label": "PER", "start": 57, "end": 69}]
-    _, results_agg = compute_metrics(true_named_entities, pred_named_entities, ["PER"])
+    _, results_agg, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER"])
     expected_agg = {
         "PER": {
             "strict": {
@@ -270,7 +270,7 @@ def test_compute_metrics_agg_scenario_5():
 def test_compute_metrics_agg_scenario_4():
     true_named_entities = [{"label": "PER", "start": 59, "end": 69}]
     pred_named_entities = [{"label": "LOC", "start": 59, "end": 69}]
-    _, results_agg = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC"])
+    _, results_agg, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC"])
     expected_agg = {
         "PER": {
             "strict": {
@@ -384,7 +384,7 @@ def test_compute_metrics_agg_scenario_4():
 def test_compute_metrics_agg_scenario_1():
     true_named_entities = [{"label": "PER", "start": 59, "end": 69}]
     pred_named_entities = [{"label": "PER", "start": 59, "end": 69}]
-    _, results_agg = compute_metrics(true_named_entities, pred_named_entities, ["PER"])
+    _, results_agg, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER"])
     expected_agg = {
         "PER": {
             "strict": {
@@ -447,7 +447,7 @@ def test_compute_metrics_agg_scenario_1():
 def test_compute_metrics_agg_scenario_6():
     true_named_entities = [{"label": "PER", "start": 59, "end": 69}]
     pred_named_entities = [{"label": "LOC", "start": 54, "end": 69}]
-    _, results_agg = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC"])
+    _, results_agg, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC"])
     expected_agg = {
         "PER": {
             "strict": {
@@ -570,7 +570,7 @@ def test_compute_metrics_extra_tags_in_prediction():
         {"label": "ORG", "start": 59, "end": 69},  # Correct
         {"label": "MISC", "start": 71, "end": 72},  # Wrong type
     ]
-    results, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC", "ORG"])
+    results, _, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC", "ORG"])
     expected = {
         "strict": {
             "correct": 1,
@@ -641,7 +641,7 @@ def test_compute_metrics_extra_tags_in_true():
         {"label": "ORG", "start": 71, "end": 72},  # Spurious
     ]
 
-    results, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC", "ORG"])
+    results, _, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "LOC", "ORG"])
 
     expected = {
         "strict": {
@@ -707,7 +707,7 @@ def test_compute_metrics_no_predictions():
         {"label": "MISC", "start": 71, "end": 72},
     ]
     pred_named_entities = []
-    results, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "ORG", "MISC"])
+    results, _, _, _ = compute_metrics(true_named_entities, pred_named_entities, ["PER", "ORG", "MISC"])
     expected = {
         "strict": {
             "correct": 0,
@@ -831,8 +831,8 @@ def test_compute_metrics_one_pred_two_true():
         {"start": 0, "end": 17, "label": "A"},
     ]
 
-    results1, _ = compute_metrics(true_named_entities_1, pred_named_entities, ["A", "B"])
-    results2, _ = compute_metrics(true_named_entities_2, pred_named_entities, ["A", "B"])
+    results1, _, _, _ = compute_metrics(true_named_entities_1, pred_named_entities, ["A", "B"])
+    results2, _, _, _ = compute_metrics(true_named_entities_2, pred_named_entities, ["A", "B"])
 
     expected = {
         'ent_type': {


### PR DESCRIPTION
Hi 👋 I would like `nervaluate`'s results to show me the examples where my NER model makes mistakes, i.e false positive/false negatives. This functionality has already been mentioned in issue #68.

I have made some simple additions to `evaluate.py`, but this will break a lot of tests. I'm happy to adapt them, but I want to first check if we are happy with this form of additional information before I continue 😄 

Here's an example of how the changes affect the output:

```
from nervaluate import Evaluator


def test_evaluator_simple_case():
    true = [
        [{"label": "PER", "start": 2, "end": 4}],
        [
            {"label": "LOC", "start": 1, "end": 2},
        ],
        [
            {"label": "LOC", "start": 1, "end": 2},
            {"label": "LOC", "start": 3, "end": 4}, # missed
        ],
        [
            {"label": "PER", "start": 27, "end": 29},
        ],
        [
            {"label": "LOC", "start": 4, "end": 7},
        ],
    ]
    pred = [
        [{"label": "PER", "start": 2, "end": 4}],
        [
            {"label": "LOC", "start": 1, "end": 2},
            {"label": "PER", "start": 13, "end": 14}, # false positive (spurious)
        ],
        [
            {"label": "LOC", "start": 1, "end": 2},
        ],
        [
            {"label": "PER", "start": 28, "end": 31}, # partial
        ],
        [
            {"label": "LOC", "start": 4, "end": 7},
            {"label": "LOC", "start": 24, "end": 26}, # another false positive (spurious)
        ],
    ]
    evaluator = Evaluator(true, pred, tags=["LOC", "PER"])
    results, results_agg = evaluator.evaluate()

    return results, results_agg
```

Our overall results will look like:

```
{'ent_type': {'correct': 5,
  'incorrect': 0,
  'incorrect_indices': [],
  'partial': 0,
  'partial_indices': [],
  'missed': 1,
  'missed_indices': [2],
  'spurious': 2,
  'spurious_indices': [1, 4],
  'possible': 6,
  'actual': 7,
  'precision': 0.7142857142857143,
  'recall': 0.8333333333333334,
  'f1': 0.7692307692307692},
 'partial': {'correct': 4,
  'incorrect': 0,
  'incorrect_indices': [],
  'partial': 1,
  'partial_indices': [3],
  'missed': 1,
  'missed_indices': [2],
  'spurious': 2,
  'spurious_indices': [1, 4],
  'possible': 6,
  'actual': 7,
  'precision': 0.6428571428571429,
  'recall': 0.75,
  'f1': 0.6923076923076924},
 'strict': {'correct': 4,
  'incorrect': 1,
  'incorrect_indices': [3],
  'partial': 0,
  'partial_indices': [],
  'missed': 1,
  'missed_indices': [2],
  'spurious': 2,
  'spurious_indices': [1, 4],
  'possible': 6,
  'actual': 7,
  'precision': 0.5714285714285714,
  'recall': 0.6666666666666666,
  'f1': 0.6153846153846153},
 'exact': {'correct': 4,
  'incorrect': 1,
  'incorrect_indices': [3],
  'partial': 0,
  'partial_indices': [],
  'missed': 1,
  'missed_indices': [2],
  'spurious': 2,
  'spurious_indices': [1, 4],
  'possible': 6,
  'actual': 7,
  'precision': 0.5714285714285714,
  'recall': 0.6666666666666666,
  'f1': 0.6153846153846153}}
```

The relevant indices will also be added on the per-tag output.