### PR TITLE
feat: defining a min ground truth percentage to be considered an overlap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ disable = [
     "R0801",  # duplicate-code
     "W9020",  # bad-option-value
     "W0621",  # redefined-outer-name
+    "W0212",  # protected-access
 ]
 
 [tool.pylint.'DESIGN']

--- a/src/nervaluate/evaluator.py
+++ b/src/nervaluate/evaluator.py
@@ -17,7 +17,9 @@ from .entities import Entity
 class Evaluator:
     """Main evaluator class for NER evaluation."""
 
-    def __init__(self, true: Any, pred: Any, tags: List[str], loader: str = "default") -> None:
+    def __init__(
+        self, true: Any, pred: Any, tags: List[str], loader: str = "default", min_overlap_percentage: float = 1.0
+    ) -> None:
         """
         Initialize the evaluator.
 
@@ -26,8 +28,10 @@ class Evaluator:
             pred: Predicted entities in any supported format
             tags: List of valid entity tags
             loader: Name of the loader to use
+            min_overlap_percentage: Minimum overlap percentage for partial matches (1-100)
         """
         self.tags = tags
+        self.min_overlap_percentage = min_overlap_percentage
         self._setup_loaders()
         self._load_data(true, pred, loader)
         self._setup_evaluation_strategies()
@@ -37,12 +41,12 @@ class Evaluator:
         self.loaders: Dict[str, DataLoader] = {"conll": ConllLoader(), "list": ListLoader(), "dict": DictLoader()}
 
     def _setup_evaluation_strategies(self) -> None:
-        """Setup evaluation strategies."""
+        """Setup evaluation strategies with overlap threshold."""
         self.strategies: Dict[str, EvaluationStrategy] = {
-            "strict": StrictEvaluation(),
-            "partial": PartialEvaluation(),
-            "ent_type": EntityTypeEvaluation(),
-            "exact": ExactEvaluation(),
+            "strict": StrictEvaluation(self.min_overlap_percentage),
+            "partial": PartialEvaluation(self.min_overlap_percentage),
+            "ent_type": EntityTypeEvaluation(self.min_overlap_percentage),
+            "exact": ExactEvaluation(self.min_overlap_percentage),
         }
 
     def _load_data(self, true: Any, pred: Any, loader: str) -> None:

--- a/src/nervaluate/strategies.py
+++ b/src/nervaluate/strategies.py
@@ -14,11 +14,12 @@ class EvaluationStrategy(ABC):
         Args:
             min_overlap_percentage: Minimum overlap percentage required (1-100)
         """
-        if not (1.0 <= min_overlap_percentage <= 100.0):
+        if not 1.0 <= min_overlap_percentage <= 100.0:
             raise ValueError("min_overlap_percentage must be between 1.0 and 100.0")
         self.min_overlap_percentage = min_overlap_percentage
 
-    def _calculate_overlap_percentage(self, pred: Entity, true: Entity) -> float:
+    @staticmethod
+    def _calculate_overlap_percentage(pred: Entity, true: Entity) -> float:
         """
         Calculate the percentage overlap between predicted and true entities.
 
@@ -42,7 +43,7 @@ class EvaluationStrategy(ABC):
 
     def _has_sufficient_overlap(self, pred: Entity, true: Entity) -> bool:
         """Check if entities have sufficient overlap based on threshold."""
-        overlap_percentage = self._calculate_overlap_percentage(pred, true)
+        overlap_percentage = EvaluationStrategy._calculate_overlap_percentage(pred, true)
         return overlap_percentage >= self.min_overlap_percentage
 
     @abstractmethod

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -170,7 +170,6 @@ def test_results_to_csv(sample_data, tmp_path):
 
 def test_evaluator_with_min_overlap_percentage():
     """Test Evaluator class with minimum overlap percentage parameter."""
-    from nervaluate import Evaluator
 
     # Test data: true entity spans positions 0-9 (10 tokens)
     true_entities = [[{"label": "PER", "start": 0, "end": 9}]]  # 10-token entity

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -166,3 +166,191 @@ def test_results_to_csv(sample_data, tmp_path):
     # test invalid scenario for entities mode
     with pytest.raises(ValueError, match="Invalid scenario: must be one of"):
         evaluator.results_to_csv(mode="entities", scenario="invalid")
+
+
+def test_evaluator_with_min_overlap_percentage():
+    """Test Evaluator class with minimum overlap percentage parameter."""
+    from nervaluate import Evaluator
+
+    # Test data: true entity spans positions 0-9 (10 tokens)
+    true_entities = [[{"label": "PER", "start": 0, "end": 9}]]  # 10-token entity
+
+    # Predicted entities with different overlap percentages
+    pred_entities = [[{"label": "PER", "start": 0, "end": 2}]]  # 30% overlap
+
+    # Test with default 1% threshold - should be partial match
+    evaluator_default = Evaluator(true=true_entities, pred=pred_entities, tags=["PER"], loader="dict")
+    results_default = evaluator_default.evaluate()
+    partial_default = results_default["overall"]["partial"]
+    assert partial_default.partial == 1
+    assert partial_default.spurious == 0
+
+    # Test with 50% threshold - should be spurious
+    evaluator_50 = Evaluator(
+        true=true_entities, pred=pred_entities, tags=["PER"], loader="dict", min_overlap_percentage=50.0
+    )
+    results_50 = evaluator_50.evaluate()
+    partial_50 = results_50["overall"]["partial"]
+    assert partial_50.partial == 0
+    assert partial_50.spurious == 1
+
+
+def test_evaluator_min_overlap_validation():
+    """Test that Evaluator validates minimum overlap percentage."""
+    true_entities = [[{"label": "PER", "start": 0, "end": 5}]]
+    pred_entities = [[{"label": "PER", "start": 0, "end": 5}]]
+
+    # Valid values should work
+    Evaluator(true_entities, pred_entities, ["PER"], "dict", min_overlap_percentage=1.0)
+    Evaluator(true_entities, pred_entities, ["PER"], "dict", min_overlap_percentage=50.0)
+    Evaluator(true_entities, pred_entities, ["PER"], "dict", min_overlap_percentage=100.0)
+
+    # Invalid values should raise ValueError during strategy initialization
+    with pytest.raises(ValueError, match="min_overlap_percentage must be between 1.0 and 100.0"):
+        Evaluator(true_entities, pred_entities, ["PER"], "dict", min_overlap_percentage=0.5)
+
+    with pytest.raises(ValueError, match="min_overlap_percentage must be between 1.0 and 100.0"):
+        Evaluator(true_entities, pred_entities, ["PER"], "dict", min_overlap_percentage=101.0)
+
+
+def test_evaluator_min_overlap_affects_all_strategies():
+    """Test that minimum overlap percentage affects all evaluation strategies."""
+    true_entities = [[{"label": "PER", "start": 0, "end": 9}]]  # 10 tokens
+
+    pred_entities = [[{"label": "PER", "start": 0, "end": 2}]]  # 30% overlap
+
+    evaluator = Evaluator(
+        true=true_entities, pred=pred_entities, tags=["PER"], loader="dict", min_overlap_percentage=50.0
+    )
+
+    results = evaluator.evaluate()
+
+    # All strategies should respect the 50% threshold
+    # 30% overlap < 50% threshold, so should be spurious for all strategies
+
+    # Partial strategy
+    partial_result = results["overall"]["partial"]
+    assert partial_result.spurious == 1
+    assert partial_result.correct == 0
+    assert partial_result.partial == 0
+
+    # Strict strategy
+    strict_result = results["overall"]["strict"]
+    assert strict_result.spurious == 1
+    assert strict_result.correct == 0
+    assert strict_result.incorrect == 0
+
+    # Entity type strategy
+    ent_type_result = results["overall"]["ent_type"]
+    assert ent_type_result.spurious == 1
+    assert ent_type_result.correct == 0
+    assert ent_type_result.incorrect == 0
+
+    # Exact strategy
+    exact_result = results["overall"]["exact"]
+    assert exact_result.spurious == 1
+    assert exact_result.correct == 0
+    assert exact_result.incorrect == 0
+
+
+def test_evaluator_min_overlap_with_different_thresholds():
+    """Test Evaluator with different overlap thresholds."""
+    true_entities = [[{"label": "PER", "start": 0, "end": 9}]]  # 10 tokens
+
+    # Test cases with different predicted entities
+    test_cases = [
+        # (pred_entities, threshold, expected_result_type)
+        ([{"label": "PER", "start": 0, "end": 4}], 50.0, "partial"),  # 50% overlap = 50%
+        ([{"label": "PER", "start": 0, "end": 4}], 51.0, "spurious"),  # 50% overlap < 51%
+        ([{"label": "PER", "start": 0, "end": 6}], 75.0, "spurious"),  # 70% overlap < 75%
+        ([{"label": "PER", "start": 0, "end": 7}], 75.0, "partial"),  # 80% overlap > 75%
+        ([{"label": "PER", "start": 0, "end": 9}], 100.0, "correct"),  # 100% overlap = exact match
+    ]
+
+    for pred_data, threshold, expected_type in test_cases:
+        pred_entities = [pred_data]
+
+        evaluator = Evaluator(
+            true=true_entities, pred=pred_entities, tags=["PER"], loader="dict", min_overlap_percentage=threshold
+        )
+
+        results = evaluator.evaluate()
+        partial_results = results["overall"]["partial"]
+
+        if expected_type == "correct":
+            assert partial_results.correct == 1, f"Failed for {pred_data} with threshold {threshold}%"
+            assert partial_results.partial == 0
+            assert partial_results.spurious == 0
+        elif expected_type == "partial":
+            assert partial_results.partial == 1, f"Failed for {pred_data} with threshold {threshold}%"
+            assert partial_results.correct == 0
+            assert partial_results.spurious == 0
+        elif expected_type == "spurious":
+            assert partial_results.spurious == 1, f"Failed for {pred_data} with threshold {threshold}%"
+            assert partial_results.correct == 0
+            assert partial_results.partial == 0
+
+
+def test_evaluator_min_overlap_with_multiple_entities():
+    """Test Evaluator with multiple entities and minimum overlap threshold."""
+    true_entities = [
+        [
+            {"label": "PER", "start": 0, "end": 4},  # 5 tokens
+            {"label": "ORG", "start": 10, "end": 14},  # 5 tokens
+            {"label": "LOC", "start": 20, "end": 24},  # 5 tokens
+        ]
+    ]
+
+    pred_entities = [
+        [
+            {"label": "PER", "start": 0, "end": 1},  # 40% overlap (2/5 tokens)
+            {"label": "ORG", "start": 10, "end": 12},  # 60% overlap (3/5 tokens)
+            {"label": "LOC", "start": 20, "end": 24},  # 100% overlap (exact match)
+            {"label": "MISC", "start": 30, "end": 32},  # No overlap (spurious)
+        ]
+    ]
+
+    # Test with 50% threshold
+    evaluator = Evaluator(
+        true=true_entities,
+        pred=pred_entities,
+        tags=["PER", "ORG", "LOC", "MISC"],
+        loader="dict",
+        min_overlap_percentage=50.0,
+    )
+
+    results = evaluator.evaluate()
+    partial_results = results["overall"]["partial"]
+
+    assert partial_results.correct == 1  # LOC exact match
+    assert partial_results.partial == 1  # ORG 60% overlap > 50%
+    assert partial_results.spurious == 2  # PER 40% < 50% and MISC no overlap
+    assert partial_results.missed == 1  # PER entity not sufficiently matched
+
+
+def test_evaluator_min_overlap_backward_compatibility():
+    """Test that the new feature maintains backward compatibility."""
+    true_entities = [[{"label": "PER", "start": 0, "end": 9}]]
+
+    pred_entities = [[{"label": "PER", "start": 9, "end": 9}]]  # 10% overlap (1 token out of 10)
+
+    # Without specifying min_overlap_percentage (should default to 1.0)
+    evaluator_default = Evaluator(true=true_entities, pred=pred_entities, tags=["PER"], loader="dict")
+
+    # With explicitly setting to 1.0
+    evaluator_explicit = Evaluator(
+        true=true_entities, pred=pred_entities, tags=["PER"], loader="dict", min_overlap_percentage=1.0
+    )
+
+    results_default = evaluator_default.evaluate()
+    results_explicit = evaluator_explicit.evaluate()
+
+    # Results should be identical
+    for strategy in ["strict", "partial", "ent_type", "exact"]:
+        default_result = results_default["overall"][strategy]
+        explicit_result = results_explicit["overall"][strategy]
+
+        assert default_result.correct == explicit_result.correct
+        assert default_result.partial == explicit_result.partial
+        assert default_result.spurious == explicit_result.spurious
+        assert default_result.missed == explicit_result.missed

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -500,3 +500,263 @@ class TestPartialEvaluation:
         assert result_indices.partial_indices == []
         assert result_indices.missed_indices == []
         assert result_indices.spurious_indices == [(0, 1)]
+
+
+def test_minimum_overlap_percentage_validation():
+    """Test that minimum overlap percentage validation works correctly."""
+    from nervaluate.strategies import PartialEvaluation
+
+    # Valid values should work
+    PartialEvaluation(min_overlap_percentage=1.0)
+    PartialEvaluation(min_overlap_percentage=50.0)
+    PartialEvaluation(min_overlap_percentage=100.0)
+
+    # Invalid values should raise ValueError
+    with pytest.raises(ValueError, match="min_overlap_percentage must be between 1.0 and 100.0"):
+        PartialEvaluation(min_overlap_percentage=0.5)
+
+    with pytest.raises(ValueError, match="min_overlap_percentage must be between 1.0 and 100.0"):
+        PartialEvaluation(min_overlap_percentage=101.0)
+
+    with pytest.raises(ValueError, match="min_overlap_percentage must be between 1.0 and 100.0"):
+        PartialEvaluation(min_overlap_percentage=-5.0)
+
+
+def test_overlap_percentage_calculation():
+    """Test the overlap percentage calculation method."""
+    from nervaluate.strategies import PartialEvaluation
+    from nervaluate.entities import Entity
+
+    strategy = PartialEvaluation(min_overlap_percentage=50.0)
+
+    true_entity = Entity(label="PER", start=0, end=9)  # 10 tokens (0-9 inclusive)
+
+    test_cases = [
+        # (pred_entity, expected_percentage)
+        (Entity(label="PER", start=0, end=9), 100.0),  # Complete overlap
+        (Entity(label="PER", start=0, end=4), 50.0),  # Half overlap from start
+        (Entity(label="PER", start=5, end=9), 50.0),  # Half overlap from end
+        (Entity(label="PER", start=0, end=0), 10.0),  # Single token overlap at start
+        (Entity(label="PER", start=9, end=9), 10.0),  # Single token overlap at end
+        (Entity(label="PER", start=10, end=15), 0.0),  # No overlap (adjacent)
+        (Entity(label="PER", start=-5, end=2), 30.0),  # Partial overlap from left (3 tokens: 0,1,2)
+        (Entity(label="PER", start=7, end=12), 30.0),  # Partial overlap from right (3 tokens: 7,8,9)
+        (Entity(label="PER", start=2, end=7), 60.0),  # Middle overlap (6 tokens: 2,3,4,5,6,7)
+    ]
+
+    for pred_entity, expected_percentage in test_cases:
+        calculated = strategy._calculate_overlap_percentage(pred_entity, true_entity)
+        assert (
+            abs(calculated - expected_percentage) < 0.1
+        ), f"Expected {expected_percentage}%, got {calculated}% for pred={pred_entity} vs true={true_entity}"
+
+
+def test_has_sufficient_overlap():
+    """Test the has_sufficient_overlap method with different thresholds."""
+    from nervaluate.strategies import PartialEvaluation
+    from nervaluate.entities import Entity
+
+    true_entity = Entity(label="PER", start=0, end=9)  # 10 tokens
+
+    # Test with 50% threshold
+    strategy_50 = PartialEvaluation(min_overlap_percentage=50.0)
+
+    # Should pass: 50% or more overlap
+    assert strategy_50._has_sufficient_overlap(Entity(label="PER", start=0, end=4), true_entity)  # 50%
+    assert strategy_50._has_sufficient_overlap(Entity(label="PER", start=0, end=6), true_entity)  # 70%
+    assert strategy_50._has_sufficient_overlap(Entity(label="PER", start=0, end=9), true_entity)  # 100%
+
+    # Should fail: less than 50% overlap
+    assert not strategy_50._has_sufficient_overlap(Entity(label="PER", start=0, end=2), true_entity)  # 30%
+    assert not strategy_50._has_sufficient_overlap(Entity(label="PER", start=0, end=0), true_entity)  # 10%
+    assert not strategy_50._has_sufficient_overlap(Entity(label="PER", start=10, end=15), true_entity)  # 0%
+
+    # Test with 75% threshold
+    strategy_75 = PartialEvaluation(min_overlap_percentage=75.0)
+
+    # Should pass: 75% or more overlap
+    assert strategy_75._has_sufficient_overlap(Entity(label="PER", start=0, end=7), true_entity)  # 80%
+    assert strategy_75._has_sufficient_overlap(Entity(label="PER", start=0, end=9), true_entity)  # 100%
+
+    # Should fail: less than 75% overlap
+    assert not strategy_75._has_sufficient_overlap(Entity(label="PER", start=0, end=6), true_entity)  # 70%
+    assert not strategy_75._has_sufficient_overlap(Entity(label="PER", start=0, end=4), true_entity)  # 50%
+
+
+def test_partial_evaluation_with_min_overlap():
+    """Test PartialEvaluation strategy with different minimum overlap thresholds."""
+    from nervaluate.strategies import PartialEvaluation
+    from nervaluate.entities import Entity
+
+    true_entities = [Entity(label="PER", start=0, end=9)]  # 10 tokens
+
+    test_cases = [
+        # (pred_entity, min_overlap_threshold, expected_correct, expected_partial, expected_spurious)
+        (Entity(label="PER", start=0, end=4), 50.0, 0, 1, 0),  # 50% overlap -> partial
+        (Entity(label="PER", start=0, end=2), 50.0, 0, 0, 1),  # 30% overlap < 50% -> spurious
+        (Entity(label="PER", start=0, end=9), 50.0, 1, 0, 0),  # 100% overlap exact match -> correct
+        (Entity(label="PER", start=0, end=6), 75.0, 0, 0, 1),  # 70% overlap < 75% -> spurious
+        (Entity(label="PER", start=0, end=7), 75.0, 0, 1, 0),  # 80% overlap > 75% -> partial
+    ]
+
+    for pred_entity, threshold, expected_correct, expected_partial, expected_spurious in test_cases:
+        pred_entities = [pred_entity]
+        strategy = PartialEvaluation(min_overlap_percentage=threshold)
+        result, indices = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
+
+        assert (
+            result.correct == expected_correct
+        ), f"Expected {expected_correct} correct, got {result.correct} for {pred_entity} with threshold {threshold}%"
+        assert (
+            result.partial == expected_partial
+        ), f"Expected {expected_partial} partial, got {result.partial} for {pred_entity} with threshold {threshold}%"
+        assert (
+            result.spurious == expected_spurious
+        ), f"Expected {expected_spurious} spurious, got {result.spurious} for {pred_entity} with threshold {threshold}%"
+
+
+def test_strict_evaluation_with_min_overlap():
+    """Test StrictEvaluation strategy with minimum overlap threshold."""
+    from nervaluate.strategies import StrictEvaluation
+    from nervaluate.entities import Entity
+
+    true_entities = [Entity(label="PER", start=0, end=9)]
+
+    # Test case where pred has insufficient overlap -> should be spurious
+    pred_entities = [Entity(label="PER", start=0, end=2)]  # 30% overlap
+    strategy = StrictEvaluation(min_overlap_percentage=50.0)
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
+
+    assert result.correct == 0
+    assert result.incorrect == 0
+    assert result.spurious == 1  # Insufficient overlap -> spurious
+    assert result.missed == 1  # True entity not matched
+
+    # Test case where pred has sufficient overlap but wrong label -> should be incorrect
+    pred_entities = [Entity(label="ORG", start=0, end=6)]  # 70% overlap, wrong label
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+
+    assert result.correct == 0
+    assert result.incorrect == 1  # Sufficient overlap but wrong label
+    assert result.spurious == 0
+    assert result.missed == 0
+
+
+def test_entity_type_evaluation_with_min_overlap():
+    """Test EntityTypeEvaluation strategy with minimum overlap threshold."""
+    from nervaluate.strategies import EntityTypeEvaluation
+    from nervaluate.entities import Entity
+
+    true_entities = [Entity(label="PER", start=0, end=9)]
+
+    # Test case: sufficient overlap with correct label -> correct
+    pred_entities = [Entity(label="PER", start=0, end=6)]  # 70% overlap, correct label
+    strategy = EntityTypeEvaluation(min_overlap_percentage=50.0)
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
+
+    assert result.correct == 1
+    assert result.incorrect == 0
+    assert result.spurious == 0
+    assert result.missed == 0
+
+    # Test case: sufficient overlap with wrong label -> incorrect
+    pred_entities = [Entity(label="ORG", start=0, end=6)]  # 70% overlap, wrong label
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+
+    assert result.correct == 0
+    assert result.incorrect == 1
+    assert result.spurious == 0
+    assert result.missed == 0
+
+    # Test case: insufficient overlap -> spurious
+    pred_entities = [Entity(label="PER", start=0, end=2)]  # 30% overlap < 50%
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
+
+    assert result.correct == 0
+    assert result.incorrect == 0
+    assert result.spurious == 1
+    assert result.missed == 1
+
+
+def test_exact_evaluation_with_min_overlap():
+    """Test ExactEvaluation strategy with minimum overlap threshold."""
+    from nervaluate.strategies import ExactEvaluation
+    from nervaluate.entities import Entity
+
+    true_entities = [Entity(label="PER", start=0, end=9)]
+
+    # Test case: exact boundaries (different label) -> correct
+    pred_entities = [Entity(label="ORG", start=0, end=9)]  # Exact match, different label
+    strategy = ExactEvaluation(min_overlap_percentage=50.0)
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+
+    assert result.correct == 1
+    assert result.incorrect == 0
+    assert result.spurious == 0
+    assert result.missed == 0
+
+    # Test case: sufficient overlap but not exact -> incorrect
+    pred_entities = [Entity(label="ORG", start=0, end=6)]  # 70% overlap, not exact
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+
+    assert result.correct == 0
+    assert result.incorrect == 1
+    assert result.spurious == 0
+    assert result.missed == 0
+
+    # Test case: insufficient overlap -> spurious
+    pred_entities = [Entity(label="ORG", start=0, end=2)]  # 30% overlap < 50%
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+
+    assert result.correct == 0
+    assert result.incorrect == 0
+    assert result.spurious == 1
+    assert result.missed == 1
+
+
+def test_edge_cases_overlap_calculation():
+    """Test edge cases for overlap calculation."""
+    from nervaluate.strategies import PartialEvaluation
+    from nervaluate.entities import Entity
+
+    strategy = PartialEvaluation(min_overlap_percentage=100.0)
+
+    # Test single-token entities
+    true_single = Entity(label="ORG", start=5, end=5)  # Single token
+    pred_single = Entity(label="ORG", start=5, end=5)  # Exact match
+
+    overlap = strategy._calculate_overlap_percentage(pred_single, true_single)
+    assert overlap == 100.0, "Single token exact match should be 100%"
+
+    # Test adjacent but non-overlapping entities
+    pred_adjacent = Entity(label="ORG", start=6, end=6)  # Adjacent token
+    overlap = strategy._calculate_overlap_percentage(pred_adjacent, true_single)
+    assert overlap == 0.0, "Adjacent non-overlapping should be 0%"
+
+    # Test overlapping single-token entities
+    pred_overlap = Entity(label="ORG", start=4, end=6)  # Overlaps with true_single at position 5
+    overlap = strategy._calculate_overlap_percentage(pred_overlap, true_single)
+    assert overlap == 100.0, "Single token overlap should be 100% of true entity"
+
+
+def test_multiple_entities_with_min_overlap():
+    """Test evaluation with multiple entities and minimum overlap."""
+    from nervaluate.strategies import PartialEvaluation
+    from nervaluate.entities import Entity
+
+    true_entities = [Entity(label="PER", start=0, end=4), Entity(label="ORG", start=10, end=14)]  # 5 tokens  # 5 tokens
+
+    pred_entities = [
+        Entity(label="PER", start=0, end=1),  # 40% overlap with first entity
+        Entity(label="ORG", start=10, end=12),  # 60% overlap with second entity
+        Entity(label="LOC", start=20, end=22),  # No overlap (spurious)
+    ]
+
+    # With 50% threshold
+    strategy = PartialEvaluation(min_overlap_percentage=50.0)
+    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG", "LOC"], 0)
+
+    assert result.correct == 0
+    assert result.partial == 1  # Only the ORG entity has sufficient overlap (60% > 50%)
+    assert result.spurious == 2  # PER entity (40% < 50%) and LOC entity (no overlap)
+    assert result.missed == 1  # First true entity (PER) not sufficiently matched

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -504,7 +504,6 @@ class TestPartialEvaluation:
 
 def test_minimum_overlap_percentage_validation():
     """Test that minimum overlap percentage validation works correctly."""
-    from nervaluate.strategies import PartialEvaluation
 
     # Valid values should work
     PartialEvaluation(min_overlap_percentage=1.0)
@@ -524,9 +523,6 @@ def test_minimum_overlap_percentage_validation():
 
 def test_overlap_percentage_calculation():
     """Test the overlap percentage calculation method."""
-    from nervaluate.strategies import PartialEvaluation
-    from nervaluate.entities import Entity
-
     strategy = PartialEvaluation(min_overlap_percentage=50.0)
 
     true_entity = Entity(label="PER", start=0, end=9)  # 10 tokens (0-9 inclusive)
@@ -553,8 +549,6 @@ def test_overlap_percentage_calculation():
 
 def test_has_sufficient_overlap():
     """Test the has_sufficient_overlap method with different thresholds."""
-    from nervaluate.strategies import PartialEvaluation
-    from nervaluate.entities import Entity
 
     true_entity = Entity(label="PER", start=0, end=9)  # 10 tokens
 
@@ -585,8 +579,6 @@ def test_has_sufficient_overlap():
 
 def test_partial_evaluation_with_min_overlap():
     """Test PartialEvaluation strategy with different minimum overlap thresholds."""
-    from nervaluate.strategies import PartialEvaluation
-    from nervaluate.entities import Entity
 
     true_entities = [Entity(label="PER", start=0, end=9)]  # 10 tokens
 
@@ -602,7 +594,7 @@ def test_partial_evaluation_with_min_overlap():
     for pred_entity, threshold, expected_correct, expected_partial, expected_spurious in test_cases:
         pred_entities = [pred_entity]
         strategy = PartialEvaluation(min_overlap_percentage=threshold)
-        result, indices = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
+        result, _ = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
 
         assert (
             result.correct == expected_correct
@@ -617,15 +609,13 @@ def test_partial_evaluation_with_min_overlap():
 
 def test_strict_evaluation_with_min_overlap():
     """Test StrictEvaluation strategy with minimum overlap threshold."""
-    from nervaluate.strategies import StrictEvaluation
-    from nervaluate.entities import Entity
 
     true_entities = [Entity(label="PER", start=0, end=9)]
 
     # Test case where pred has insufficient overlap -> should be spurious
     pred_entities = [Entity(label="PER", start=0, end=2)]  # 30% overlap
     strategy = StrictEvaluation(min_overlap_percentage=50.0)
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
 
     assert result.correct == 0
     assert result.incorrect == 0
@@ -634,7 +624,7 @@ def test_strict_evaluation_with_min_overlap():
 
     # Test case where pred has sufficient overlap but wrong label -> should be incorrect
     pred_entities = [Entity(label="ORG", start=0, end=6)]  # 70% overlap, wrong label
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
 
     assert result.correct == 0
     assert result.incorrect == 1  # Sufficient overlap but wrong label
@@ -644,15 +634,13 @@ def test_strict_evaluation_with_min_overlap():
 
 def test_entity_type_evaluation_with_min_overlap():
     """Test EntityTypeEvaluation strategy with minimum overlap threshold."""
-    from nervaluate.strategies import EntityTypeEvaluation
-    from nervaluate.entities import Entity
 
     true_entities = [Entity(label="PER", start=0, end=9)]
 
     # Test case: sufficient overlap with correct label -> correct
     pred_entities = [Entity(label="PER", start=0, end=6)]  # 70% overlap, correct label
     strategy = EntityTypeEvaluation(min_overlap_percentage=50.0)
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
 
     assert result.correct == 1
     assert result.incorrect == 0
@@ -661,7 +649,7 @@ def test_entity_type_evaluation_with_min_overlap():
 
     # Test case: sufficient overlap with wrong label -> incorrect
     pred_entities = [Entity(label="ORG", start=0, end=6)]  # 70% overlap, wrong label
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
 
     assert result.correct == 0
     assert result.incorrect == 1
@@ -670,7 +658,7 @@ def test_entity_type_evaluation_with_min_overlap():
 
     # Test case: insufficient overlap -> spurious
     pred_entities = [Entity(label="PER", start=0, end=2)]  # 30% overlap < 50%
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER"], 0)
 
     assert result.correct == 0
     assert result.incorrect == 0
@@ -680,15 +668,13 @@ def test_entity_type_evaluation_with_min_overlap():
 
 def test_exact_evaluation_with_min_overlap():
     """Test ExactEvaluation strategy with minimum overlap threshold."""
-    from nervaluate.strategies import ExactEvaluation
-    from nervaluate.entities import Entity
 
     true_entities = [Entity(label="PER", start=0, end=9)]
 
     # Test case: exact boundaries (different label) -> correct
     pred_entities = [Entity(label="ORG", start=0, end=9)]  # Exact match, different label
     strategy = ExactEvaluation(min_overlap_percentage=50.0)
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
 
     assert result.correct == 1
     assert result.incorrect == 0
@@ -697,7 +683,7 @@ def test_exact_evaluation_with_min_overlap():
 
     # Test case: sufficient overlap but not exact -> incorrect
     pred_entities = [Entity(label="ORG", start=0, end=6)]  # 70% overlap, not exact
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
 
     assert result.correct == 0
     assert result.incorrect == 1
@@ -706,7 +692,7 @@ def test_exact_evaluation_with_min_overlap():
 
     # Test case: insufficient overlap -> spurious
     pred_entities = [Entity(label="ORG", start=0, end=2)]  # 30% overlap < 50%
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG"], 0)
 
     assert result.correct == 0
     assert result.incorrect == 0
@@ -716,8 +702,6 @@ def test_exact_evaluation_with_min_overlap():
 
 def test_edge_cases_overlap_calculation():
     """Test edge cases for overlap calculation."""
-    from nervaluate.strategies import PartialEvaluation
-    from nervaluate.entities import Entity
 
     strategy = PartialEvaluation(min_overlap_percentage=100.0)
 
@@ -741,8 +725,6 @@ def test_edge_cases_overlap_calculation():
 
 def test_multiple_entities_with_min_overlap():
     """Test evaluation with multiple entities and minimum overlap."""
-    from nervaluate.strategies import PartialEvaluation
-    from nervaluate.entities import Entity
 
     true_entities = [Entity(label="PER", start=0, end=4), Entity(label="ORG", start=10, end=14)]  # 5 tokens  # 5 tokens
 
@@ -754,7 +736,7 @@ def test_multiple_entities_with_min_overlap():
 
     # With 50% threshold
     strategy = PartialEvaluation(min_overlap_percentage=50.0)
-    result, indices = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG", "LOC"], 0)
+    result, _ = strategy.evaluate(true_entities, pred_entities, ["PER", "ORG", "LOC"], 0)
 
     assert result.correct == 0
     assert result.partial == 1  # Only the ORG entity has sufficient overlap (60% > 50%)


### PR DESCRIPTION
### Related Issues

- fixes #83 

### Proposed Changes:

- Adding a `min_overlap_percentage: float = 1.0` to the `PartialEvaluation` and `EntityTypeEvaluation` evaluation strategies.
- A partial match is only considered if the match overlap is equal or abve the defined `min_overlap_percentage`
 
### How did you test it?

- local unit tests + CI tests

### Checklist

- I have read the [contributors guidelines](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/deepset-ai/haystack/blob/main/code_of_conduct.txt)
- I have updated the related issue with new insights and changes
- I added unit tests and updated the docstrings
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` and added `!` in case the PR includes breaking changes.
- I documented my code
- I ran [pre-commit hooks](https://github.com/deepset-ai/haystack/blob/main/CONTRIBUTING.md#installation) and fixed any issue
